### PR TITLE
Add models for cluster overview details card

### DIFF
--- a/console/models/CatalogSourceModel.ts
+++ b/console/models/CatalogSourceModel.ts
@@ -1,0 +1,22 @@
+import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
+
+import { modelToGroupVersionKind, modelToRef } from '../modelUtils';
+
+const CatalogSourceModel: K8sModel = {
+  kind: 'CatalogSource',
+  label: 'CatalogSource',
+  labelKey: 'CatalogSource',
+  labelPlural: 'CatalogSources',
+  labelPluralKey: 'CatalogSources',
+  apiGroup: 'operators.coreos.com',
+  apiVersion: 'v1alpha1',
+  abbr: 'CS',
+  namespaced: true,
+  crd: true,
+  plural: 'catalogsources',
+};
+
+export const CatalogSourceModelGroupVersionKind = modelToGroupVersionKind(CatalogSourceModel);
+export const CatalogSourceModelRef = modelToRef(CatalogSourceModel);
+
+export default CatalogSourceModel;

--- a/console/models/ClusterServiceVersionModel.ts
+++ b/console/models/ClusterServiceVersionModel.ts
@@ -1,0 +1,24 @@
+import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
+
+import { modelToGroupVersionKind, modelToRef } from '../modelUtils';
+
+const ClusterServiceVersionModel: K8sModel = {
+  kind: 'ClusterServiceVersion',
+  label: 'ClusterServiceVersion',
+  labelKey: 'ClusterServiceVersion',
+  labelPlural: 'ClusterServiceVersions',
+  labelPluralKey: 'ClusterServiceVersions',
+  apiGroup: 'operators.coreos.com',
+  apiVersion: 'v1alpha1',
+  abbr: 'CSV',
+  namespaced: true,
+  crd: true,
+  plural: 'clusterserviceversions',
+  propagationPolicy: 'Foreground',
+  legacyPluralURL: true,
+};
+
+export const ClusterServiceVersionModelGroupVersionKind = modelToGroupVersionKind(ClusterServiceVersionModel);
+export const ClusterServiceVersionModelRef = modelToRef(ClusterServiceVersionModel);
+
+export default ClusterServiceVersionModel;

--- a/console/models/InstallPlanModel.ts
+++ b/console/models/InstallPlanModel.ts
@@ -1,0 +1,23 @@
+import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
+
+import { modelToGroupVersionKind, modelToRef } from '../modelUtils';
+
+const InstallPlanModel: K8sModel = {
+  kind: 'InstallPlan',
+  label: 'InstallPlan',
+  labelKey: 'InstallPlan',
+  labelPlural: 'InstallPlans',
+  labelPluralKey: 'InstallPlans',
+  apiGroup: 'operators.coreos.com',
+  apiVersion: 'v1alpha1',
+  abbr: 'IP',
+  namespaced: true,
+  crd: true,
+  plural: 'installplans',
+  legacyPluralURL: true,
+};
+
+export const InstallPlanModelGroupVersionKind = modelToGroupVersionKind(InstallPlanModel);
+export const InstallPlanModelRef = modelToRef(InstallPlanModel);
+
+export default InstallPlanModel;


### PR DESCRIPTION
This PR adds models needed by the details card of the cluster overview.