### PR TITLE
Add ConsoleQuickStartModel

### DIFF
--- a/console/models/ConsoleQuickStartModel.ts
+++ b/console/models/ConsoleQuickStartModel.ts
@@ -1,0 +1,21 @@
+import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
+
+import { modelToGroupVersionKind, modelToRef } from '../modelUtils';
+
+const ConsoleQuickStartModel: K8sModel = {
+  kind: 'ConsoleQuickStart',
+  label: 'ConsoleQuickStart',
+  labelPlural: 'ConsoleQuickStarts',
+  apiGroup: 'console.openshift.io',
+  apiVersion: 'v1',
+  abbr: 'CQS',
+  namespaced: false,
+  crd: true,
+  plural: 'consolequickstarts',
+  propagationPolicy: 'Background',
+};
+
+export const ConsoleQuickStartModelGroupVersionKind = modelToGroupVersionKind(ConsoleQuickStartModel);
+export const ConsoleQuickStartModelRef = modelToRef(ConsoleQuickStartModel);
+
+export default ConsoleQuickStartModel;

--- a/console/models/index.ts
+++ b/console/models/index.ts
@@ -3,6 +3,7 @@
 export * from './CatalogSourceModel';
 export * from './ClusterServiceVersionModel';
 export * from './CDIConfigModel';
+export * from './ConsoleQuickStartModel';
 export * from './DataSourceModel';
 export * from './DataVolumeModel';
 export * from './HyperConvergedModel';


### PR DESCRIPTION
Adds the `ConsoleQuickStartModel` for the quick starts section of the overview page.