### PR TITLE
Add ConsoleCLIDownloadModel

### DIFF
--- a/console/models/ConsoleCLIDownloadModel.ts
+++ b/console/models/ConsoleCLIDownloadModel.ts
@@ -1,0 +1,25 @@
+import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
+import { modelToGroupVersionKind, modelToRef } from '../modelUtils';
+
+const ConsoleCLIDownloadModel: K8sModel = {
+  label: 'ConsoleCLIDownload',
+  // t('public~ConsoleCLIDownload')
+  labelKey: 'public~ConsoleCLIDownload',
+  labelPlural: 'ConsoleCLIDownloads',
+  // t('public~ConsoleCLIDownloads')
+  labelPluralKey: 'public~ConsoleCLIDownloads',
+  apiVersion: 'v1',
+  apiGroup: 'console.openshift.io',
+  plural: 'consoleclidownloads',
+  abbr: 'CCD',
+  namespaced: false,
+  kind: 'ConsoleCLIDownload',
+  id: 'consoleclidownload',
+  crd: true,
+};
+
+export const ConsoleCLIDownloadModelGroupVersionKind =
+  modelToGroupVersionKind(ConsoleCLIDownloadModel);
+export const ConsoleCLIDownloadModelRef = modelToRef(ConsoleCLIDownloadModel);
+
+export default ConsoleCLIDownloadModel;

--- a/console/models/index.ts
+++ b/console/models/index.ts
@@ -3,6 +3,7 @@
 export * from './CatalogSourceModel';
 export * from './ClusterServiceVersionModel';
 export * from './CDIConfigModel';
+export * from './ConsoleCLIDownloadModel';
 export * from './ConsoleQuickStartModel';
 export * from './DataSourceModel';
 export * from './DataImportCronModel';


### PR DESCRIPTION
This PR adds the `ConsoleCLIDownloadModel` which will be used when adding `virtctl` download options to cluster overview page. 