### PR TITLE
Fix VirtualMachineInstancetype model to be namespaced

### DIFF
--- a/console/models/VirtualMachineInstancetypeModel.ts
+++ b/console/models/VirtualMachineInstancetypeModel.ts
@@ -9,7 +9,7 @@ export const VirtualMachineInstancetypeModel: K8sModel = {
   apiGroup: 'instancetype.kubevirt.io',
   plural: 'virtualmachineinstancetypes',
   abbr: 'VMCI',
-  namespaced: false,
+  namespaced: true,
   kind: 'VirtualMachineInstancetype',
   id: 'virtualmachineinstancetype',
   crd: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubevirt-ui/kubevirt-api",
-  "version": "1.7.0",
+  "version": "1.8.1",
   "description": "kubevirt OpenAPI automation for TypeScript",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Set `namespaced: true` on `VirtualMachineInstancetypeModel` so the console model matches the namespaced VirtualMachineInstancetype CRD
- Bump package version to 1.8.1

## Test plan
- [ ] Verify `VirtualMachineInstancetypeModel.namespaced` is `true`
- [ ] Confirm namespace-scoped instancetype resources resolve correctly in console consumers

**What this PR does / why we need it**:

`VirtualMachineInstancetype` is a namespaced KubeVirt CRD, but the console model was incorrectly marked as cluster-scoped (`namespaced: false`). This fix aligns the model definition with the actual API scope.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix VirtualMachineInstancetype console model scope to namespaced and release v1.8.1
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VirtualMachineInstancetype resource namespace scoping behavior to ensure proper isolation and correct handling across Kubernetes namespaces. Resources are now correctly filtered, scoped, and managed within their respective namespaces, preventing unintended cross-namespace access and improving overall system security and consistency in multi-environment deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->