### PR TITLE
CNV-92386: Fix FieldsV1 type incompatibility between kubevirt-api and Console SDK 4.23.0-prerelease.3

### DIFF
--- a/containerized-data-importer/models/V1FieldsV1.ts
+++ b/containerized-data-importer/models/V1FieldsV1.ts
@@ -5,4 +5,4 @@
  *
  * The exact format is defined in sigs.k8s.io/structured-merge-diff
  */
-export type V1FieldsV1 = object;
+export type V1FieldsV1 = Record<string, unknown>;

--- a/kubernetes/models/IoK8sApimachineryPkgApisMetaV1FieldsV1.ts
+++ b/kubernetes/models/IoK8sApimachineryPkgApisMetaV1FieldsV1.ts
@@ -5,4 +5,4 @@
  *
  * The exact format is defined in sigs.k8s.io/structured-merge-diff
  */
-export type IoK8sApimachineryPkgApisMetaV1FieldsV1 = object;
+export type IoK8sApimachineryPkgApisMetaV1FieldsV1 = Record<string, unknown>;

--- a/kubevirt/models/K8sIoApimachineryPkgApisMetaV1FieldsV1.ts
+++ b/kubevirt/models/K8sIoApimachineryPkgApisMetaV1FieldsV1.ts
@@ -5,4 +5,4 @@
  *
  * The exact format is defined in sigs.k8s.io/structured-merge-diff
  */
-export type K8sIoApimachineryPkgApisMetaV1FieldsV1 = object;
+export type K8sIoApimachineryPkgApisMetaV1FieldsV1 = Record<string, unknown>;

--- a/scripts/split-data-contracts.mjs
+++ b/scripts/split-data-contracts.mjs
@@ -35,6 +35,32 @@ const BUILTIN_TYPES = new Set([
 
 const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
 
+const FIELDS_V1_TYPE_ALIASES = new Set([
+  'K8sIoApimachineryPkgApisMetaV1FieldsV1',
+  'IoK8sApimachineryPkgApisMetaV1FieldsV1',
+  'V1FieldsV1',
+]);
+
+function applyFieldsV1TypeOverride(declaration) {
+  if (
+    !ts.isTypeAliasDeclaration(declaration) ||
+    !FIELDS_V1_TYPE_ALIASES.has(declaration.name.text)
+  ) {
+    return declaration;
+  }
+
+  return ts.factory.updateTypeAliasDeclaration(
+    declaration,
+    declaration.modifiers,
+    declaration.name,
+    declaration.typeParameters,
+    ts.factory.createTypeReferenceNode('Record', [
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+    ]),
+  );
+}
+
 function getLeadingCommentText(sourceFile, node) {
   const start = node.getStart(sourceFile, false);
   const ranges = ts.getLeadingCommentRanges(sourceFile.text, start);
@@ -304,7 +330,7 @@ function splitDataContracts(inputPath, outputDir) {
       declaration,
       sourceFile,
     );
-    processedDeclarations.push(updatedDeclaration);
+    processedDeclarations.push(applyFieldsV1TypeOverride(updatedDeclaration));
 
     for (const enumType of enumTypes) {
       extractedEnumTypes.set(enumType.name, enumType);


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the `FieldsV1` type alias from `object` to `Record<string, unknown>` in all three API packages (kubevirt, containerized-data-importer, kubernetes).

This fixes a TypeScript structural incompatibility with `@openshift-console/dynamic-plugin-sdk` 4.23, which re-exports `K8sResourceCommon` from `@openshift/api-types`. The SDK defines `FieldsV1` as an empty interface (`{}`), which has an implicit index signature. TypeScript's `object` type lacks an index signature, making `V1VirtualMachine` (and all other KubeVirt resource types) unassignable to `K8sResourceCommon` — causing 1929 compilation errors in kubevirt-plugin.

`Record<string, unknown>` is structurally compatible with the SDK's empty interface and is fully backwards compatible with all existing consumers.

**Which issue(s) this PR fixes** 

Jira ticket: [CNV-92386](https://redhat.atlassian.net/browse/CNV-92386)

**Special notes for your reviewer**:

- This is a type-only change with no runtime impact
- `Record<string, unknown>` is a supertype of `object` — all existing code that reads or writes `fieldsV1` continues to work unchanged
- The fix is required to unblock the Console SDK 4.23 upgrade in kubevirt-plugin

**Release note**:
```release-note
Fix FieldsV1 type compatibility with OpenShift Console SDK 4.23 by changing the type alias from `object` to `Record<string, unknown>`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened typing for structured `*V1FieldsV1`-style fields to use string-keyed key/value maps (`Record<string, unknown>`) instead of a broad object type.
  * Improved type safety and correctness when handling these metadata-like dictionaries.
* **Chores**
  * Updated the data-contract splitting script to consistently apply the `Record<string, unknown>` override for matching exported `*V1FieldsV1` type aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->