### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubevirt-ui/kubevirt-api",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "kubevirt OpenAPI automation for TypeScript",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Bump package version to **2.1.0** in preparation for the next npm release
- This release includes the FieldsV1 type fix merged in #89 (CNV-92386), which aligns `FieldsV1` with the OpenShift Console SDK 4.23.0-prerelease.3

## Test plan
- [ ] CI passes (`yarn build`)
- [ ] Publish GitHub release `v2.1.0` after merge to trigger npm publish

**What this PR does / why we need it**:

Prepares the 2.1.0 release so consumers can install a version that includes the FieldsV1 compatibility fix from #89.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Version-only change. After merge, publish the GitHub release to trigger the npm publish workflow.

**Release note**:
```release-note
Bump version to 2.1.0, including the FieldsV1 type fix for OpenShift Console SDK 4.23.0 compatibility.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version from 2.0.0 to 2.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->