### PR TITLE
CNV-92386: Fix FieldsV1 type incompatibility between kubevirt-api and Console SDK 4.23.0-prerelease.3

### DIFF
--- a/containerized-data-importer/models/V1FieldsV1.ts
+++ b/containerized-data-importer/models/V1FieldsV1.ts
@@ -5,4 +5,6 @@
  *
  * The exact format is defined in sigs.k8s.io/structured-merge-diff
  */
-export type V1FieldsV1 = Record<string, unknown>;
+export interface V1FieldsV1 {
+  [field: string]: V1FieldsV1 | Record<string, never>;
+}

--- a/kubernetes/models/IoK8sApimachineryPkgApisMetaV1FieldsV1.ts
+++ b/kubernetes/models/IoK8sApimachineryPkgApisMetaV1FieldsV1.ts
@@ -5,4 +5,6 @@
  *
  * The exact format is defined in sigs.k8s.io/structured-merge-diff
  */
-export type IoK8sApimachineryPkgApisMetaV1FieldsV1 = Record<string, unknown>;
+export interface IoK8sApimachineryPkgApisMetaV1FieldsV1 {
+  [field: string]: IoK8sApimachineryPkgApisMetaV1FieldsV1 | Record<string, never>;
+}

--- a/kubevirt/models/K8sIoApimachineryPkgApisMetaV1FieldsV1.ts
+++ b/kubevirt/models/K8sIoApimachineryPkgApisMetaV1FieldsV1.ts
@@ -5,4 +5,6 @@
  *
  * The exact format is defined in sigs.k8s.io/structured-merge-diff
  */
-export type K8sIoApimachineryPkgApisMetaV1FieldsV1 = Record<string, unknown>;
+export interface K8sIoApimachineryPkgApisMetaV1FieldsV1 {
+  [field: string]: K8sIoApimachineryPkgApisMetaV1FieldsV1 | Record<string, never>;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubevirt-ui/kubevirt-api",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "kubevirt OpenAPI automation for TypeScript",
   "type": "module",
   "exports": {

--- a/scripts/split-data-contracts.mjs
+++ b/scripts/split-data-contracts.mjs
@@ -49,15 +49,34 @@ function applyFieldsV1TypeOverride(declaration) {
     return declaration;
   }
 
-  return ts.factory.updateTypeAliasDeclaration(
-    declaration,
+  const typeName = declaration.name.text;
+
+  return ts.factory.createInterfaceDeclaration(
     declaration.modifiers,
     declaration.name,
-    declaration.typeParameters,
-    ts.factory.createTypeReferenceNode('Record', [
-      ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-      ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
-    ]),
+    undefined,
+    undefined,
+    [
+      ts.factory.createIndexSignature(
+        undefined,
+        [
+          ts.factory.createParameterDeclaration(
+            undefined,
+            undefined,
+            'field',
+            undefined,
+            ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+          ),
+        ],
+        ts.factory.createUnionTypeNode([
+          ts.factory.createTypeReferenceNode(typeName),
+          ts.factory.createTypeReferenceNode('Record', [
+            ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+            ts.factory.createKeywordTypeNode(ts.SyntaxKind.NeverKeyword),
+          ]),
+        ]),
+      ),
+    ],
   );
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the `FieldsV1` type alias from `object` to `Record<string, unknown>` in all three API packages (kubevirt, containerized-data-importer, kubernetes).

This fixes a TypeScript structural incompatibility with `@openshift-console/dynamic-plugin-sdk` 4.23, which re-exports `K8sResourceCommon` from `@openshift/api-types`. The SDK defines `FieldsV1` as an empty interface (`{}`), which has an implicit index signature. TypeScript's `object` type lacks an index signature, making `V1VirtualMachine` (and all other KubeVirt resource types) unassignable to `K8sResourceCommon` — causing 1929 compilation errors in kubevirt-plugin.

`Record<string, unknown>` is structurally compatible with the SDK's empty interface and is fully backwards compatible with all existing consumers.

**Which issue(s) this PR fixes** 

Jira ticket: [CNV-92386](https://redhat.atlassian.net/browse/CNV-92386)

**Special notes for your reviewer**:

- This is a type-only change with no runtime impact
- `Record<string, unknown>` is a supertype of `object` — all existing code that reads or writes `fieldsV1` continues to work unchanged
- The fix is required to unblock the Console SDK 4.23 upgrade in kubevirt-plugin

**Release note**:
```release-note
Fix FieldsV1 type compatibility with OpenShift Console SDK 4.23 by changing the type alias from `object` to `Record<string, unknown>`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened generated contract definitions for nested field structures, so leaf and intermediate nodes are represented more accurately.
  * Reduced acceptance of invalid values in structured field trees, improving type-safety for downstream tooling and integrations.
* **Chores**
  * Bumped the package version to **2.1.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->